### PR TITLE
Add method to access queue name in Msg

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -22,6 +22,10 @@ func (m *Msg) Jid() string {
 	return m.Get("jid").MustString()
 }
 
+func (m *Msg) Queue() string {
+	return m.Get("queue").MustString()
+}
+
 func (m *Msg) Args() *Args {
 	if args, ok := m.CheckGet("args"); ok {
 		return &Args{&data{args}}

--- a/msg_test.go
+++ b/msg_test.go
@@ -24,6 +24,13 @@ func MsgSpec(c gospec.Context) {
 		})
 	})
 
+	c.Specify("Queue", func() {
+		c.Specify("returns queue key", func() {
+			msg, _ := NewMsg("{\"hello\":\"world\",\"queue\":\"default\"}")
+			c.Expect(msg.Queue(), Equals, "default")
+		})
+	})
+
 	c.Specify("Args", func() {
 		c.Specify("returns args key", func() {
 			msg, _ := NewMsg("{\"hello\":\"world\",\"args\":[\"foo\",\"bar\"]}")


### PR DESCRIPTION
Allow to access queue name on `Msg`.